### PR TITLE
Update readme title and add blank agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
-# Carpentries Maintainer Meeting Minutes
+# Carpentries Maintainer Resources
 
-This repository will serve as an archive for the maintainer community meeting minutes, held every third Wednesday of the month.
+This repository will serve as a place for maintainer resources in  additon to an archive for the maintainer community meeting minutes, held every third Wednesday of the month.
+
+
+Blank maintainer meeting agenda:
+
+```
+![The Carpentries logo](https://codimd.carpentries.org/uploads/upload_b540836e1a3d8721461f64b24a9526d4.png)
+---
+
+# Lesson Maintainers
+
+## Connection information:
+
+***Link to connect to video call***
+NOTE: Effective 2020-09-27, Zoom is requiring passwords on all meeting rooms.
+Please use the link https://carpentries.zoom.us/my/carpentriesroom2?pwd=WmVCOUlPUm1laFk5SUp1UWg5cjhEUT09
+to join the room directly or enter the password **202020** when prompted. 
+
+***To join by phone*** - look for the phone number for your country at the bottom of this Etherpad.
+If you don't see a number for your country, please contact <team@carpentries.org>.
+
+## Upcoming meetings:
+
+Please see the community calendar (https://carpentries.org/community/#community-events)
+for all upcoming Maintainer meetings and to copy these events to your personal calendar.
+
+### Monthly Maintainer's Meeting, Jan XXXXX
+
+**Date and time 1:** https://www.timeanddate.com/worldclock/fixedtime.html?msg=Co-Working+Session&iso=2021MMDDT17
+**Date and time 2:** https://www.timeanddate.com/worldclock/fixedtime.html?msg=Co-Working+Session&iso=2021MMDDT22
+**Zoom:**     https://carpentries.zoom.us/my/carpentriesroom2?pwd=WmVCOUlPUm1laFk5SUp1UWg5cjhEUT09
+
+   Password is **202020**
+
+---
+
+## Monthly Maintainer's Meeting, XXXXX
+
+1st meeting:
+Attending (1st Meeting):
+
+- Name (pronouns), Affiliation, Lesson
+
+2nd meeting:
+Attending (2nd Meeting): 
+
+- Name (pronouns), Affiliation, Lesson
+
+Timekeeper:
+1. 
+2. 
+
+Notetaker (please add notes within agenda below):
+1. 
+2. 
+
+### Agenda:
+
+#### 1. Introductions (5 min)
+
+#### 2. Updates from Carpentries team (10 min)
+
+#### 4. Topic of the Month (30-40 min)
+
+#### 5. Current Maintainer Request for Comment (RFCs): (10 min)
+
+#### 6. Topics/Lesson issues to discuss (please add links to the issues you'd like feedback or insight on) (30 min)
+
+###### Questions from Co-working session
+
+###### For next meeting
+
+```


### PR DESCRIPTION
Change the readme title to reflect repo name change.

I also added a blank agenda to make it easier to copy/paste. This will be a temporary location, and will eventually be added to the maintainer handbook: https://docs.carpentries.org/topic_folders/maintainers/maintainers.html